### PR TITLE
Correct typo in keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/jettro/elasticsearch-gui.git"
   },
   "keywords": [
-    "elasrticsearch",
+    "elasticsearch",
     "plugin",
     "gui"
   ],


### PR DESCRIPTION
While reading [a blog](http://amsterdam.luminis.eu/2014/12/10/improve-my-angularjs-project-with-grunt/), I noticed that `elasticsearch` was misspelled. Because this is a vital part in finding the tool I corrected that mistake in this pull-request.
